### PR TITLE
Fix address field handling in contact form

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -815,7 +815,7 @@
 
                 phone: "required",
 
-                adress: "required",
+                address: "required",
 
                 service: "required",   
 
@@ -825,7 +825,7 @@
                 name: "Please enter your name",
                 email: "Please enter your email address",
                 phone: "Please enter your phone number",
-                adress: "Please enter your adress",
+                address: "Please enter your address",
                 service: "Please select your contact service",
             },
 

--- a/contact.html
+++ b/contact.html
@@ -254,7 +254,7 @@
                                     <input type="email" class="form-control" name="email" id="email" placeholder="Your Email*">
                                 </div>
                                 <div>
-                                    <input type="text" class="form-control" name="adress" id="adress" placeholder="Adress">
+                                    <input type="text" class="form-control" name="address" id="address" placeholder="Address">
                                 </div>
                                 <div>
                                     <select name="service" class="form-control">

--- a/mail-contact.php
+++ b/mail-contact.php
@@ -1,17 +1,19 @@
 <?php
 
-	$to = "wpoceanmarketing@gmail.com"; // this is your Email address
-	$from  = $_POST['email']; // this is the sender's Email address
-	$sender_name = $_POST['name'];
-	$adress = $_POST['adress'];
-	$service = $_POST['service'];
-	$note = $_POST['note'];
+        $to = "wpoceanmarketing@gmail.com"; // this is your Email address
+        $from  = filter_var($_POST['email'], FILTER_SANITIZE_EMAIL); // this is the sender's Email address
+        $sender_name = $_POST['name'];
+        $address = isset($_POST['address']) ? $_POST['address'] : '';
+        $service = $_POST['service'];
+        $note = $_POST['note'];
 
-	$subject = "Form submission";
+        $subject = "Form submission";
 
-	$message = $sender_name . " has send the contact message. His / Her contact Service is " . $service . " and his / her adress is "  . $adress . ". He / she wrote the following... ". "\n\n" . $note;
+        $message = $sender_name . " has sent the contact message. His / Her contact Service is " . $service .
+            " and his / her address is "  . $address . ". He / she wrote the following... \n\n" . $note;
 
-	$headers = 'From: ' . $from;
-	mail($to, $subject, $message, $headers);
+        $headers = 'From: ' . $from;
+        mail($to, $subject, $message, $headers);
 
 ?>
+


### PR DESCRIPTION
## Summary
- Correct misspelled `address` field in contact form HTML and validation script
- Sanitize and handle `address` input properly on server side mail handler

## Testing
- `php -l mail-contact.php`
- `node --check assets/js/script.js && echo 'Syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_6895942068e883229a4d0da882a412f2