### PR TITLE
feat: apply professional fonts and refine copy

### DIFF
--- a/about.html
+++ b/about.html
@@ -210,10 +210,10 @@
                         <div class="wpo-about-text">
                             <div class="wpo-about-title">
                                 <span>About Us</span>
-                                <h2>We Offer You Profesional Interior Design</h2>
+                                <h2>Professional Interior Design Solutions</h2>
                             </div>
-                            <h5>Welcome to <bold>Nesthetix Designs</bold>, where design meets purpose. We are a passionate interior design firm dedicated to transforming everyday spaces into extraordinary environments</h5>
-                           <p>With a focus on creativity, functionality, and attention to detail, we craft interiors that reflect your personality, enhance comfort, and elevate your lifestyle. Whether it’s a cozy home, a modern office, or a vibrant commercial space — our team blends aesthetics with practicality to deliver inspiring, tailor-made solutions that stand the test of time.</p>
+                            <h5>Welcome to <strong>Nesthetix Designs</strong>, where thoughtful design meets purposeful living. Our studio is dedicated to transforming ordinary spaces into refined environments.</h5>
+                           <p>Balancing creativity with function, we craft interiors that reflect your personality, heighten comfort, and elevate your lifestyle. Whether it's a cozy home, contemporary office, or vibrant commercial space, our team blends aesthetics with practicality to deliver timeless, tailor-made solutions.</p>
                             
                             <div class="btns">
                                 <a href="#" class="theme-btn" tabindex="0">Discover More</a>

--- a/assets/css/fonts-overrides.css
+++ b/assets/css/fonts-overrides.css
@@ -1,134 +1,16 @@
 /* fonts-overrides.css */
 
-/* 1. Define your @font-face blocks (if not already in style.css) */
-/* Load Marydale from Adobe Typekit */
-@import url('https://use.typekit.net/omj6rft.css');
+/* Import professional Google Fonts */
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500;700&family=Poppins:wght@300;400;500;600;700&display=swap');
 
-/* Webfont: Travelia-Light */
-@font-face {
-  font-family: 'Travelia';
-  src: url('fonts/Travelia-Light.eot');
-  /* IE9 Compat Modes */
-  src: url('fonts/Travelia-Light.eot?#iefix') format('embedded-opentype'),
-    /* IE6-IE8 */
-    url('fonts/Travelia-Light.woff') format('woff'),
-    /* Modern Browsers */
-    url('fonts/Travelia-Light.woff2') format('woff2'),
-    /* Modern Browsers */
-    url('fonts/Travelia-Light.ttf') format('truetype');
-  /* Safari, Android, iOS */
-  font-style: normal;
-  font-weight: 200;
-  text-rendering: optimizeLegibility;
-}
-
-/* Regular (400) */
-@font-face {
-  font-family: 'Travelia';
-  src: url('fonts/Travelia-Regular.woff2') format('woff2'),
-    url('fonts/Travelia-Regular.woff') format('woff');
-  font-weight: 400;
-  font-style: normal;
-  font-display: swap;
-}
-
-/* SemiBold (600) — if you need it elsewhere */
-@font-face {
-  font-family: 'Travelia';
-  src: url('fonts/Travelia-SemiBold.woff2') format('woff2'),
-    url('fonts/Travelia-SemiBold.woff') format('woff');
-  font-weight: 600;
-  font-style: normal;
-  font-display: swap;
-}
-
-/* Bold (700) */
-@font-face {
-  font-family: 'Travelia';
-  src: url('fonts/Travelia-Bold.woff2') format('woff2'),
-    url('fonts/Travelia-Bold.woff') format('woff');
+/* Headings adopt a refined serif typeface */
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Playfair Display', serif !important;
   font-weight: 700;
-  font-style: normal;
-  font-display: swap;
 }
 
-/* ExtraBold (800) */
-@font-face {
-  font-family: 'Travelia';
-  src: url('fonts/Travelia-ExtraBold.woff2') format('woff2'),
-    url('fonts/Travelia-ExtraBold.woff') format('woff');
-  font-weight: 800;
-  font-style: normal;
-  font-display: swap;
-}
-
-/* Black (900) */
-@font-face {
-  font-family: 'Travelia';
-  src: url('fonts/Travelia-Black.woff2') format('woff2'),
-    url('fonts/Travelia-Black.woff') format('woff');
-  font-weight: 900;
-  font-style: normal;
-  font-display: swap;
-}
-
-/* 2. Force-apply to your elements */
-h1 {
-  font-family: 'Travelia', sans-serif !important;
-  font-weight: 900 !important;
-}
-
-/* Override headings to use Marydale */
-
-/* H2 uses the 900-weight Marydale */
-h2 {
-  font-family: 'marydale', sans-serif !important;
-  font-weight: 900 !important;
-  font-style: normal !important;
-}
-
-/* H3 uses the 700-weight Marydale */
-h3, a, li {
-  font-family: 'marydale', sans-serif !important;
-  font-weight: 700 !important;
-  font-style: normal !important;
-}
-
-/* (Optional) Fallback for any other element you’d like in Regular weight */
-.some-selector {
-  font-family: 'marydale', sans-serif !important;
-  font-weight: 400 !important;
-  font-style: normal !important;
-}
-
-
-h4 {
-  font-family: 'Travelia', sans-serif !important;
-  font-weight: 700 !important;
-}
-
-p {
-  font-family: 'Travelia', sans-serif !important;
-  font-weight: 600;
-}
-
-h5,
-h6 {
-  font-family: 'Travelia', sans-serif !important;
-  font-weight: 700 !important;
-}
-
-/* 5. Form elements & buttons too */
-input,
-textarea,
-button,
-select,
-option,
-ol {
-  font-family: 'Travelia', sans-serif !important;
-  font-weight: 700 !important;
-}
-
-mil-thin {
-  font-weight: 400 !important;
+/* Body and interface text use a clean sans-serif */
+body, p, a, li, input, textarea, button, select, option, ol {
+  font-family: 'Poppins', sans-serif !important;
+  font-weight: 400;
 }

--- a/index.html
+++ b/index.html
@@ -279,10 +279,10 @@
                         <div class="wpo-about-text">
                             <div class="wpo-about-title">
                                 <span>About Us</span>
-                                <h2>We Offer You Profesional Interior Design</h2>
+                                <h2>Professional Interior Design Solutions</h2>
                             </div>
-                           <p>Welcome to Nesthetix Designs, where design meets purpose. We are a passionate interior design firm dedicated to transforming everyday spaces into extraordinary environments</p>
-                           <p>With a focus on creativity, functionality, and attention to detail, we craft interiors that reflect your personality, enhance comfort, and elevate your lifestyle. Whether it’s a cozy home, a modern office, or a vibrant commercial space — our team blends aesthetics with practicality to deliver inspiring, tailor-made solutions that stand the test of time.</p>
+                           <p>Welcome to Nesthetix Designs, where thoughtful design meets purposeful living. Our studio transforms everyday spaces into curated environments that inspire.</p>
+                           <p>Balancing creativity with functionality, we shape interiors that reflect your personality, elevate comfort, and enhance your lifestyle. From intimate homes to modern workplaces and vibrant commercial venues, our team delivers timeless, tailor-made solutions.</p>
                             <div class="btns">
                                 <a href="#" class="theme-btn" tabindex="0">Discover More</a>
                                 <!-- <ul>

--- a/project.html
+++ b/project.html
@@ -468,7 +468,7 @@
                                 </div>
                                 <ul>
                                     <li><a href="service-single.html">Perfect Planning</a></li>
-                                    <li><a href="service-single.html">Profesional Design</a></li>
+                                    <li><a href="service-single.html">Professional Design</a></li>
                                     <li><a href="service-single.html">Best Interior</a></li>
                                     <li><a href="service-single.html">Modern Furniture</a></li>
                                     <li><a href="service-single.html">Complete Decoration</a></li>


### PR DESCRIPTION
## Summary
- replace Travelia/Marydale fonts with Playfair Display and Poppins for a clean, professional look
- polish about and home page copy to better reflect interior design standards
- fix spelling of "Professional Design" in project services list

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895ac949af0832299f0b1aaabf31e6d